### PR TITLE
feat: Add containerized deployment for ServiceAccount token rotation

### DIFF
--- a/runai/storage_monitor/.dockerignore
+++ b/runai/storage_monitor/.dockerignore
@@ -1,0 +1,7 @@
+.venv/
+__pycache__/
+*.pyc
+*.egg-info/
+.git/
+.gitignore
+deploy/

--- a/runai/storage_monitor/Dockerfile
+++ b/runai/storage_monitor/Dockerfile
@@ -28,6 +28,10 @@ COPY . .
 # Install the storage monitor package
 RUN pip install --no-cache-dir .
 
+# Run as non-root user
+RUN useradd -r -s /usr/sbin/nologin monitor
+USER monitor
+
 # FastAPI dashboard port
 EXPOSE 8081
 

--- a/runai/storage_monitor/Dockerfile
+++ b/runai/storage_monitor/Dockerfile
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install OS dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy package files
+COPY . .
+
+# Install the storage monitor package
+RUN pip install --no-cache-dir .
+
+# FastAPI dashboard port
+EXPOSE 8081
+
+# Server auto-detects Docker (/.dockerenv) and binds to 0.0.0.0
+CMD ["runai-storage-server"]

--- a/runai/storage_monitor/README.md
+++ b/runai/storage_monitor/README.md
@@ -17,59 +17,28 @@ limitations under the License.
 
 # Run.ai Storage Monitor
 
-Kubernetes storage visibility tool for Run.ai environments - web GUI for identifying unused PVCs, tracking storage usage, and getting actionable cleanup recommendations.
+![Version](https://img.shields.io/badge/version-1.0.1-blue) ![Python](https://img.shields.io/badge/python-3.8%2B-green) ![License](https://img.shields.io/badge/license-Apache%202.0-orange)
 
-A community example tool for DGX Cloud Run.ai deployments.
+Kubernetes storage visibility tool for Run.ai environments -- web GUI for identifying unused PVCs, tracking storage quotas, and getting cleanup recommendations.
 
 ## Quick Start
 
 ```bash
-# 1. Authenticate to Run.ai (first time or when token expires)
+# Authenticate and get credentials
 runai login
-
-# 2. Update kubectl credentials
 runai kubeconfig set
 
-# 3. Install tool
+# Install and launch
 pip install -e .
-
-# 4. Launch GUI
 runai-storage-server
-
-# 5. Open browser
-http://127.0.0.1:8081
+# Open http://127.0.0.1:8081
 ```
 
-## Features
-
-- **Web GUI** for storage visibility across Run.ai namespaces
-- List all Run.ai namespaces
-- Analyze PVC usage and status
-- Identify unused PVCs for cleanup
-- Track storage quotas and limits
-- Real-time WebSocket updates
-- Export analysis to JSON/CSV
-- Permission validation
+To use a custom kubeconfig: `export KUBECONFIG=/path/to/config`
 
 ## Installation
 
-### Prerequisites
-
-- Python 3.8+
-- **Run.ai CLI** installed ([Download from Run.ai UI](https://docs.nvidia.com/dgx-cloud/run-ai/latest/advanced.html#downloading-the-nvidia-run-ai-cli))
-- **kubectl** installed
-- **Kubeconfig file** from your cluster administrator
-- Read-only K8s permissions (list namespaces, PVCs, pods)
-
-**First-Time Setup:**
-1. Place kubeconfig in `~/.kube/config` (or set `KUBECONFIG` environment variable)
-2. `runai login` - Opens browser for SSO authentication
-3. `runai kubeconfig set` - Retrieves OIDC token for kubeconfig
-4. `kubectl get nodes` - Verify cluster access works
-
-See full setup guide: [DGX Cloud CLI/API Setup](https://docs.nvidia.com/dgx-cloud/run-ai/latest/advanced.html#setting-up-your-kubernetes-configuration-file)
-
-### Install
+**Prerequisites:** Python 3.8+, [Run.ai CLI](https://docs.nvidia.com/dgx-cloud/run-ai/latest/advanced.html#downloading-the-nvidia-run-ai-cli), kubectl, kubeconfig with read-only K8s access.
 
 ```bash
 git clone <repository-url>
@@ -77,52 +46,11 @@ cd runai_storage_monitor
 pip install -e .
 ```
 
-### Verify Installation
-
-```bash
-runai-storage-monitor --version
-# Should output: runai-storage-monitor, version 1.0.1
-```
-
-### Launch GUI
-
-```bash
-runai-storage-server
-```
-
-Opens at `http://127.0.0.1:8081`
-
-## Configuration
-
-### Custom Kubeconfig
-
-```bash
-runai-storage-server
-# Uses default ~/.kube/config
-```
-
-For custom kubeconfig path, set `KUBECONFIG` environment variable:
-```bash
-export KUBECONFIG=/path/to/config
-runai-storage-server
-```
-
-### Kubernetes Context
-
-```bash
-kubectl config use-context <your-context>
-runai-storage-server
-```
+Verify: `runai-storage-monitor --version`
 
 ## Persistent Deployments (ServiceAccount)
 
-For long-running deployments where you don't want to re-authenticate every 24 hours, use a Kubernetes ServiceAccount instead of OIDC user tokens.
-
-### Why ServiceAccount?
-
-- OIDC tokens expire (15 min access / 24 hr refresh) requiring `runai login` again
-- ServiceAccount tokens are long-lived or auto-refreshed by Kubernetes
-- Ideal for monitoring dashboards, automation, and CI/CD pipelines
+For long-running deployments, use a Kubernetes ServiceAccount instead of OIDC user tokens that expire every 24 hours.
 
 ### Step 1: Create ServiceAccount and RBAC
 
@@ -161,24 +89,43 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ```
 
-Apply to your cluster:
-
 ```bash
 kubectl apply -f storage-monitor-rbac.yaml
 ```
 
-### Step 2: Generate Kubeconfig for ServiceAccount
+### Step 2: Deploy as a Kubernetes Pod (Recommended)
+
+Deploy as a Pod and Kubernetes handles token rotation automatically -- no static tokens or manual refresh.
 
 ```bash
-# Create a long-lived token (1 year) - requires K8s 1.24+
+# Build image
+cd runai/storage_monitor
+docker build -t storage-monitor:1.0.1 .
+
+# Deploy (push image to your registry first)
+kubectl apply -f deploy/deployment.yaml
+kubectl apply -f deploy/service.yaml
+
+# Access dashboard
+kubectl port-forward svc/storage-monitor 8081:8081
+# Open http://localhost:8081
+```
+
+### Alternative: External Kubeconfig (with Token)
+
+Run outside the cluster using a ServiceAccount token in a kubeconfig.
+
+> **Token duration cap:** Managed platforms (including DGX Cloud) may configure `--service-account-max-token-expiration` on the API server, which silently caps `kubectl create token --duration`. If your token expires in 24 hours despite requesting longer, use the **Pod deployment** above or a **Secret-based token** below.
+
+```bash
+# Create token (actual duration may be capped by API server)
 kubectl create token storage-monitor -n default --duration=8760h > /tmp/sa-token
 
-# Get cluster connection info from current kubeconfig
+# Build kubeconfig
 CLUSTER_NAME=$(kubectl config view --minify -o jsonpath='{.clusters[0].name}')
 CLUSTER_SERVER=$(kubectl config view --minify -o jsonpath='{.clusters[0].cluster.server}')
 CLUSTER_CA=$(kubectl config view --minify --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}')
 
-# Generate ServiceAccount kubeconfig
 cat > ~/.kube/storage-monitor-config <<EOF
 apiVersion: v1
 kind: Config
@@ -199,55 +146,49 @@ users:
       token: $(cat /tmp/sa-token)
 EOF
 
-# Clean up temp file
 rm /tmp/sa-token
 ```
-
-### Step 3: Run with ServiceAccount Kubeconfig
 
 ```bash
 export KUBECONFIG=~/.kube/storage-monitor-config
 runai-storage-server
 ```
 
-The dashboard will now run indefinitely without token expiration.
+### Alternative: Secret-Based Token (Bypasses Duration Cap)
 
-### Security Notes
+If the API server caps `kubectl create token` duration and you can't deploy as a Pod, create a Secret-based token. This uses the token controller (not the TokenRequest API) and is not subject to `--service-account-max-token-expiration`.
 
-- The ServiceAccount has **read-only** access (list/get only)
-- Cannot create, modify, or delete any Kubernetes resources
-- Token duration can be adjusted (default example: 1 year)
-- For tighter security, scope to specific namespaces instead of ClusterRole
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storage-monitor-token
+  namespace: default
+  annotations:
+    kubernetes.io/service-account.name: storage-monitor
+type: kubernetes.io/service-account-token
+```
+
+```bash
+kubectl apply -f storage-monitor-secret.yaml
+
+# Extract token
+TOKEN=$(kubectl get secret storage-monitor-token -n default -o jsonpath='{.data.token}' | base64 -d)
+```
+
+Use this token in the kubeconfig `users[].user.token` field instead of one from `kubectl create token`.
 
 ## Troubleshooting
 
-### Authentication Issues
-- **Token expired:** Run `runai login` then `runai kubeconfig set`
-- **Not authenticated:** Ensure you've completed `runai login` successfully
-- **Wrong cluster context:** Verify with `kubectl config current-context`
+- **Token expires in 24hr despite `--duration=8760h`:** Platform-level `--service-account-max-token-expiration` cap. Use Pod deployment or Secret-based token (see above).
+- **401 Unauthorized after running for a while:** OIDC token expired. Run `runai login` then `runai kubeconfig set`, or switch to ServiceAccount auth.
+- **No namespaces found:** Verify Run.ai namespaces exist (`kubectl get ns | grep runai`) and credentials are current (`runai kubeconfig set`).
+- **Check permissions:** `runai-storage-monitor check-permissions` shows what the current credentials can access.
 
-### "No namespaces found"
-- Check kubeconfig: `kubectl config current-context`
-- Verify Run.ai installation: `kubectl get namespaces | grep runai`
-- Refresh credentials: `runai kubeconfig set`
-
-### "Unable to connect to the server"
-- Ensure kubeconfig is valid: `kubectl cluster-info`
-- Check permissions: `runai-storage-monitor check-permissions`
-- Verify authentication: `runai whoami`
-
-### "WebSocket connection failed"
-- Use HTTP polling as fallback
-- Check firewall/proxy settings
-
-## CLI Usage
-
-For advanced CLI usage and automation:
+## CLI
 
 ```bash
 runai-storage-monitor --help
-
-# Common commands:
 runai-storage-monitor list-namespaces
 runai-storage-monitor analyze <namespace>
 runai-storage-monitor unused <namespace>
@@ -255,4 +196,4 @@ runai-storage-monitor unused <namespace>
 
 ## Support
 
-This is a community example tool. For issues or questions, please file an issue in the [dgx-cloud-examples repository](https://github.com/NVIDIA/dgx-cloud-examples/issues).
+Community example tool. File issues at [dgx-cloud-examples](https://github.com/NVIDIA/dgx-cloud-examples/issues).

--- a/runai/storage_monitor/api/server.py
+++ b/runai/storage_monitor/api/server.py
@@ -412,9 +412,8 @@ async def periodic_config_refresh():
         await asyncio.sleep(_refresh_interval)
         if _analyzer is not None:
             try:
-                # Reload kubeconfig from disk (may have been updated by runai kubeconfig set)
-                _analyzer.pvc_service.k8s._reload_config()
                 # Verify credentials work with retry semantics (1 reload+retry on 401)
+                # _with_retry handles 401 internally by calling _reload_config then retrying
                 _analyzer.pvc_service.k8s._with_retry(
                     lambda: _analyzer.pvc_service.k8s.core_v1.list_namespace(limit=1)
                 )

--- a/runai/storage_monitor/core/clients/k8s_client.py
+++ b/runai/storage_monitor/core/clients/k8s_client.py
@@ -72,6 +72,8 @@ class K8sClient:
         the token has expired. Re-reads kubeconfig from disk which may
         have been updated by `runai kubeconfig set`.
         """
+        if not self._initialized:
+            return
         logger.info("Reloading kubeconfig to refresh credentials...")
         self._initialized = False
         self._core_v1 = None

--- a/runai/storage_monitor/deploy/deployment.yaml
+++ b/runai/storage_monitor/deploy/deployment.yaml
@@ -63,4 +63,4 @@ spec:
               memory: 256Mi
           securityContext:
             readOnlyRootFilesystem: false
-            runAsNonRoot: false
+            runAsNonRoot: true

--- a/runai/storage_monitor/deploy/deployment.yaml
+++ b/runai/storage_monitor/deploy/deployment.yaml
@@ -37,7 +37,8 @@ spec:
       serviceAccountName: storage-monitor
       containers:
         - name: storage-monitor
-          image: <your-registry>/storage-monitor:1.0.1
+          # Replace with your registry, e.g.: myregistry.io/storage-monitor:1.0.1
+          image: storage-monitor:1.0.1
           ports:
             - containerPort: 8081
               name: http

--- a/runai/storage_monitor/deploy/deployment.yaml
+++ b/runai/storage_monitor/deploy/deployment.yaml
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Storage Monitor - Kubernetes Deployment
+#
+# Prerequisites:
+#   1. ServiceAccount and RBAC applied (see ../README.md "Step 1: Create ServiceAccount and RBAC")
+#   2. Container image built and available:
+#      docker build -t storage-monitor:1.0.1 ..
+#
+# Usage:
+#   kubectl apply -f deployment.yaml
+#   kubectl apply -f service.yaml
+#   kubectl port-forward svc/storage-monitor 8081:8081
+#
+# The Pod uses in-cluster ServiceAccount authentication.
+# The kubelet automatically rotates the projected SA token.
+# The Python kubernetes client re-reads the token every 60 seconds.
+# No static tokens or manual token refresh required.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: storage-monitor
+  labels:
+    app: storage-monitor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: storage-monitor
+  template:
+    metadata:
+      labels:
+        app: storage-monitor
+    spec:
+      serviceAccountName: storage-monitor
+      containers:
+        - name: storage-monitor
+          image: storage-monitor:1.0.1
+          ports:
+            - containerPort: 8081
+              name: http
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            readOnlyRootFilesystem: false
+            runAsNonRoot: false

--- a/runai/storage_monitor/deploy/deployment.yaml
+++ b/runai/storage_monitor/deploy/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       serviceAccountName: storage-monitor
       containers:
         - name: storage-monitor
-          image: storage-monitor:1.0.1
+          image: <your-registry>/storage-monitor:1.0.1
           ports:
             - containerPort: 8081
               name: http

--- a/runai/storage_monitor/deploy/service.yaml
+++ b/runai/storage_monitor/deploy/service.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Storage Monitor - Kubernetes Service
+#
+# Exposes the storage monitor dashboard within the cluster.
+# Access via:
+#   kubectl port-forward svc/storage-monitor 8081:8081
+#   Then open http://localhost:8081
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: storage-monitor
+  labels:
+    app: storage-monitor
+spec:
+  type: ClusterIP
+  selector:
+    app: storage-monitor
+  ports:
+    - port: 8081
+      targetPort: 8081
+      protocol: TCP
+      name: http


### PR DESCRIPTION
## Summary

- Adds Dockerfile, K8s Deployment + Service manifests, and .dockerignore for running the storage monitor as an in-cluster Pod
- When deployed as a Pod, projected ServiceAccount tokens rotate automatically via kubelet -- bypasses `--service-account-max-token-expiration` cap that silently limits `kubectl create token --duration` on managed platforms (e.g. DGX Cloud)
- README rewritten: focused structure, documents three auth paths (Pod deployment, external kubeconfig, Secret-based token), adds token cap troubleshooting

## Test plan

- [x] Docker build succeeds locally
- [x] Container starts, FastAPI server binds to 0.0.0.0:8081
- [x] `/health` endpoint returns 200
- [x] Dashboard root returns 200
- [ ] Deploy to K8s cluster with ServiceAccount and verify token rotation

Made with [Cursor](https://cursor.com)